### PR TITLE
Add myLevitonFan driver for DW4SF

### DIFF
--- a/myLevitonFan
+++ b/myLevitonFan
@@ -29,12 +29,13 @@ Change history:
 
 metadata
 {
-    definition(name: "My Leviton Switch/Dimmer", namespace: "tomw", author: "tomw", importUrl: "")
+    definition(name: "My Leviton Fan", namespace: "tomw", author: "tomw", importUrl: "")
     {
         capability "Refresh"
         capability "SignalStrength"
         capability "Switch"
         capability "SwitchLevel"
+        capability "FanControl"
         
         attribute "commStatus", "string"
         attribute "connected", "enum", ["true", "false"]
@@ -77,6 +78,33 @@ def on()
 def off()
 {
     lev_update_switch('OFF')
+}
+
+// Credit: https://github.com/ernie/hubitat/blob/main/drivers/leviton-zw4sf.groovy#L141-L166
+def setSpeed(speed)
+{
+  logDebug "setSpeed: ${speed}"
+
+  switch (speed) {
+    case ["low", "medium-low"]:
+      setLevel(25)
+      break
+    case "medium":
+      setLevel(50)
+      break
+    case "medium-high":
+      setLevel(75)
+      break
+    case "high":
+      setLevel(100)
+      break
+    case ["on", "auto"]:
+      return on()
+    case "off":
+      return off()
+    default:
+      logDebug "Invalid speed: ${speed}"
+  }
 }
 
 def setLevel(level)

--- a/myLevitonSystem
+++ b/myLevitonSystem
@@ -16,6 +16,7 @@ limitations under the License.
 
 Change history:
 
+1.4.0 - mingaldrichgan - added My Leviton Fan driver for DW4SF
 1.3.0 - dsegall - added support for detecting when a switch disconnects from MyLeviton
 1.2.0 - tomw + dsegall - Update device statuses from websocket events.  No more polling.
 1.0.0 - tomw - Initial release
@@ -118,7 +119,7 @@ def refreshSystemInfo()
             for(thisSwitch in switchesInfo)
             {
                 logDebug("thisSwitch = ${thisSwitch}")
-                child = manageChildDevice(thisSwitch.name, thisSwitch.id)
+                child = manageChildDevice(thisSwitch.name, thisSwitch.id, thisSwitch.customType)
                 if(child)
                 {
                     // update child device
@@ -475,12 +476,13 @@ def findChildDevice(id)
     return getChildDevice(childDni(id))
 }
 
-def createChildDevice(name, id)
+def createChildDevice(name, id, customType)
 {
-    return addChildDevice("My Leviton Switch/Dimmer", childDni(id), [label:"${childName(name)}", isComponent:false, name:"${childName(name)}"])
+    def deviceType = (customType == "ceiling-fan") ? "My Leviton Fan" : "My Leviton Switch/Dimmer"
+    return addChildDevice(deviceType, childDni(id), [label:childName(name), isComponent:false, name:deviceType])
 }
 
-def manageChildDevice(name, id)
+def manageChildDevice(name, id, customType)
 {
     logDebug("manageChildDevice(${name}, ${id})")
     
@@ -493,7 +495,7 @@ def manageChildDevice(name, id)
     else
     {
         // create child if it didn't exist...
-        child = createChildDevice(name, id)
+        child = createChildDevice(name, id, customType)
         logDebug("created new child: ${child}")
     }
     

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "hubitat_myLeviton",
   "author": "tomw",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2020-09-18",
   "drivers": [
@@ -18,10 +18,17 @@
       "namespace": "tomw",
       "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_myLeviton/master/myLevitonSwitchDimmer",
       "required": true
+    },
+    {
+      "id": "07a90b38-15ee-4969-9c7d-2cbbf7b94eac",
+      "name": "My Leviton Fan",
+      "namespace": "tomw",
+      "location": "https://raw.githubusercontent.com/tomwpublic/hubitat_myLeviton/master/myLevitonFan",
+      "required": true
     }
   ],
   "licenseFile": "https://raw.githubusercontent.com/tomwpublic/hubitat_myLeviton/master/LICENSE",
-  "releaseNotes": "1.3.0 - dsegall - added support for detecting when a switch disconnects from MyLeviton\n1.2.1 - dsegall - bugfix for canSetLevel issue.\n1.2.0 - tomw + dsegall - Update device statuses from websocket events.  No more polling.\n1.1.0 - dsegall - Added fadeTo feature and custom command.  Added support for duration parameter on setLevel command.\n1.0.0 - tomw - Initial release.",
+  "releaseNotes": "1.4.0 - mingaldrichgan - added My Leviton Fan driver for DW4SF\n1.3.0 - dsegall - added support for detecting when a switch disconnects from MyLeviton\n1.2.1 - dsegall - bugfix for canSetLevel issue.\n1.2.0 - tomw + dsegall - Update device statuses from websocket events.  No more polling.\n1.1.0 - dsegall - Added fadeTo feature and custom command.  Added support for duration parameter on setLevel command.\n1.0.0 - tomw - Initial release.",
   "documentationLink": "https://github.com/tomwpublic/hubitat_myLeviton/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/leviton-wifi-switches-dimmers/49793/11"
 }


### PR DESCRIPTION
- Added "My Leviton Fan" driver for devices with `"customType": "ceiling-fan"` e.g. the DW4SF 4-speed fan switch.
- Also fixed an issue where child devices were created with identical device name and label, whereas Hubitat convention dictates that the device name be a description of the device itself (so the driver name seems more appropriate) and the label be the user-facing name.